### PR TITLE
jasonboukheir/issue46

### DIFF
--- a/Packages/com.careboo.serially/Editor/SerializableTypeDrawer.cs
+++ b/Packages/com.careboo.serially/Editor/SerializableTypeDrawer.cs
@@ -82,7 +82,7 @@ namespace CareBoo.Serially.Editor
             return type =>
             {
                 var value = ToSerializedType(type);
-                if (property.stringValue != value && !string.IsNullOrEmpty(value))
+                if (property.stringValue != value)
                 {
                     property.stringValue = value;
                     property.serializedObject.ApplyModifiedProperties();

--- a/Packages/com.careboo.serially/Tests/Editor/SerializableTypeDrawerTest.cs
+++ b/Packages/com.careboo.serially/Tests/Editor/SerializableTypeDrawerTest.cs
@@ -112,10 +112,17 @@ namespace CareBoo.Serially.Editor.Tests
             Assert.AreEqual(expected, actual);
         }
 
-        [Test]
-        public void SetTypeValueShouldReturnSameType()
+        public static object[] SetTypeCases = new object[]
         {
-            var expected = typeof(B);
+            new object[] { typeof(A) },
+            new object[] { typeof(B) },
+            new object[] { null }
+        };
+
+        [Test]
+        [TestCaseSource(nameof(SetTypeCases))]
+        public void SetTypeValueShouldReturnSameType(Type expected)
+        {
             var property = GetProperty(nameof(NoTypeFilter));
             var typeIdProperty = property.FindPropertyRelative(TypeIdProperty);
             var setTypeValue = SerializableTypeDrawer.SetTypeValue(typeIdProperty);

--- a/Packages/com.careboo.serially/Tests/Editor/TypeFieldTest.cs
+++ b/Packages/com.careboo.serially/Tests/Editor/TypeFieldTest.cs
@@ -7,7 +7,6 @@ using System.Collections;
 using System;
 using UnityEditor;
 using UnityEditor.Callbacks;
-using UnityEngine.Events;
 
 namespace CareBoo.Serially.Editor.Tests
 {


### PR DESCRIPTION

Removing the condition that the set typestring value is not null or empty to fix the bug. The set string value should always be valid.

Fixes #46