### PR TITLE
jasonboukheir/issue53

### DIFF
--- a/Packages/com.careboo.serially/Editor/SerializableTypeDrawer.cs
+++ b/Packages/com.careboo.serially/Editor/SerializableTypeDrawer.cs
@@ -23,7 +23,7 @@ namespace CareBoo.Serially.Editor
             new TypeField(
                 position,
                 type,
-                GetFilteredTypes(property, attribute).ToArray(),
+                new Lazy<IEnumerable<Type>>(() => GetFilteredTypes(property, attribute).ToArray()),
                 SetTypeValue(typeIdProperty)
                 )
                 .DrawGui();

--- a/Packages/com.careboo.serially/Editor/SerializableTypeDrawer.cs
+++ b/Packages/com.careboo.serially/Editor/SerializableTypeDrawer.cs
@@ -20,10 +20,11 @@ namespace CareBoo.Serially.Editor
             var type = Validate(typeIdProperty.stringValue, label);
 
             position = EditorGUI.PrefixLabel(position, label);
+            var selectableTypes = new Lazy<IEnumerable<Type>>(() => GetFilteredTypes(property, attribute).ToArray());
             new TypeField(
                 position,
                 type,
-                new Lazy<IEnumerable<Type>>(() => GetFilteredTypes(property, attribute).ToArray()),
+                selectableTypes,
                 SetTypeValue(typeIdProperty)
                 )
                 .DrawGui();

--- a/Packages/com.careboo.serially/Editor/ShowSerializeReferenceDrawer.cs
+++ b/Packages/com.careboo.serially/Editor/ShowSerializeReferenceDrawer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using static UnityEditor.EditorGUIUtility;
@@ -72,7 +73,7 @@ namespace CareBoo.Serially.Editor
             new TypeField(
                 position: LabelIndent(position),
                 selectedType: property.GetManagedReferenceValueType(),
-                selectableTypes: property.GetSelectableManagedReferenceValueTypes(),
+                selectableTypes: new Lazy<IEnumerable<Type>>(property.GetSelectableManagedReferenceValueTypes),
                 onSelectType: property.SetManagedReferenceValueToNew,
                 currentEvent
                 ).DrawGui();

--- a/Packages/com.careboo.serially/Editor/TypeField.cs
+++ b/Packages/com.careboo.serially/Editor/TypeField.cs
@@ -18,7 +18,7 @@ namespace CareBoo.Serially.Editor
 
         public Rect Position { get; }
         public Type SelectedType { get; }
-        public IEnumerable<Type> SelectableTypes { get; }
+        public Lazy<IEnumerable<Type>> SelectableTypes { get; }
         public Action<Type> OnSelectType { get; }
         public GuiEvent CurrentGuiEvent { get; }
 
@@ -65,7 +65,7 @@ namespace CareBoo.Serially.Editor
         public TypeField(
             Rect position,
             Type selectedType,
-            IEnumerable<Type> selectableTypes,
+            Lazy<IEnumerable<Type>> selectableTypes,
             Action<Type> onSelectType,
             GuiEvent? currentGuiEvent = null
             )
@@ -113,7 +113,7 @@ namespace CareBoo.Serially.Editor
 
         public void HandlePickerButtonClicked()
         {
-            TypePickerWindow.ShowWindow(SelectedType, SelectableTypes, OnSelectType);
+            TypePickerWindow.ShowWindow(SelectedType, SelectableTypes.Value, OnSelectType);
         }
 
         public MonoScript HandleTypeLabelClicked()

--- a/Packages/com.careboo.serially/Tests/Editor/TypeFieldTest.cs
+++ b/Packages/com.careboo.serially/Tests/Editor/TypeFieldTest.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System;
 using UnityEditor;
 using UnityEditor.Callbacks;
+using System.Collections.Generic;
 
 namespace CareBoo.Serially.Editor.Tests
 {
@@ -23,7 +24,8 @@ namespace CareBoo.Serially.Editor.Tests
         private static bool thisScriptOpenedAtC = false;
 
         private static Rect TypeFieldRect => new Rect(x: 0, y: 0, width: 150, height: 18);
-        private static Type[] Types => new[] { typeof(A), typeof(B), typeof(C) };
+        private static Lazy<IEnumerable<Type>> Types =>
+            new Lazy<IEnumerable<Type>>(() => new[] { typeof(A), typeof(B), typeof(C) });
 
         [TearDown]
         public void CloseTestWindow()


### PR DESCRIPTION

Making Selectable types lazy because they only need to exist when the type picker is shown. Alternatively, we could be using a function instead--will decide later.

BREAKING CHANGES: Removes the IEnumerable<Type> of SelectableType parameter and replaces with a Lazy version. Fixes #53