### PR TITLE
jasonboukheir/issue54

### DIFF
--- a/Packages/com.careboo.serially/Runtime/TypeFilterAttribute.cs
+++ b/Packages/com.careboo.serially/Runtime/TypeFilterAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using UnityEngine;
 
@@ -9,9 +10,9 @@ namespace CareBoo.Serially
     {
         public Type DerivedFrom { get; }
 
-        public Func<Type, bool> DerivedFromFilter => _ => true;
+        public Func<IEnumerable<Type>, IEnumerable<Type>> DerivedFromFilter => sequence => sequence;
 
-        public Func<Type, bool> Filter { get; protected set; }
+        public Func<IEnumerable<Type>, IEnumerable<Type>> Filter { get; protected set; }
 
         public string FilterName { get; }
 
@@ -26,15 +27,15 @@ namespace CareBoo.Serially
             FilterName = filterName;
         }
 
-        public Func<Type, bool> GetFilter(object parent)
+        public Func<IEnumerable<Type>, IEnumerable<Type>> GetFilter(object parent)
         {
             return Filter ?? BindFilterDelegate(parent);
         }
 
-        public Func<Type, bool> BindFilterDelegate(object parent)
+        public Func<IEnumerable<Type>, IEnumerable<Type>> BindFilterDelegate(object parent)
         {
-            Filter = (Func<Type, bool>)Delegate.CreateDelegate(
-                typeof(Func<Type, bool>),
+            Filter = (Func<IEnumerable<Type>, IEnumerable<Type>>)Delegate.CreateDelegate(
+                typeof(Func<IEnumerable<Type>, IEnumerable<Type>>),
                 parent,
                 FilterName
                 );

--- a/Packages/com.careboo.serially/Tests/Editor/SerializableTypeDrawerTest.cs
+++ b/Packages/com.careboo.serially/Tests/Editor/SerializableTypeDrawerTest.cs
@@ -28,9 +28,9 @@ namespace CareBoo.Serially.Editor.Tests
         [TypeFilter(nameof(Filter))]
         public SerializableType DelegateTypeFilter;
 
-        public bool Filter(Type input)
+        public IEnumerable<Type> Filter(IEnumerable<Type> sequence)
         {
-            return input == typeof(B);
+            return sequence.Where(t => t == typeof(B));
         }
 
         [Test]
@@ -104,7 +104,7 @@ namespace CareBoo.Serially.Editor.Tests
         [Test]
         public void GetFilteredTypesWithTypeDelegateShouldReturnTypesMatchingDelegate()
         {
-            var expected = new HashSet<Type>(SerializableTypeDrawer.GetDerivedTypes(null).Where(Filter));
+            var expected = new HashSet<Type>(Filter(SerializableTypeDrawer.GetDerivedTypes(null)));
             var field = GetFieldInfo<SerializableTypeDrawerTest>(x => x.DelegateTypeFilter);
             var attribute = (TypeFilterAttribute)Attribute.GetCustomAttribute(field, typeof(TypeFilterAttribute));
             var property = GetProperty(nameof(DelegateTypeFilter));

--- a/Packages/com.careboo.serially/Tests/Editor/TypeFilterAttributeTest.cs
+++ b/Packages/com.careboo.serially/Tests/Editor/TypeFilterAttributeTest.cs
@@ -2,6 +2,8 @@
 using System.Reflection;
 using static CareBoo.Serially.Editor.Tests.Reflection.ReflectionUtil;
 using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace CareBoo.Serially.Editor.Tests
 {
@@ -17,9 +19,12 @@ namespace CareBoo.Serially.Editor.Tests
 
             public bool IsFiltering { get; set; }
 
-            public Func<Type, bool> FilterDelegate => Filter;
+            public Func<IEnumerable<Type>, IEnumerable<Type>> FilterDelegate => Filter;
 
-            public bool Filter(Type _) => IsFiltering;
+            public IEnumerable<Type> Filter(IEnumerable<Type> sequence)
+            {
+                return sequence.Where(_ => IsFiltering);
+            }
         }
 
         [Test]


### PR DESCRIPTION

Changing the function parameters of TypeFilterAttribute so that they're using sequences rather than taking in one type at a time. This should improve performance and be more semantically correct.

Fixes #54\nBREAKIGN CHANGES: removes Func Type -> bool support for TypeFilter